### PR TITLE
Add roadmap for Laravel drag-and-drop builder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,6 @@
-asd
+# Drag-and-Drop Page Builder Demo
+
+This repository outlines a basic plan to set up a Laravel 12 project that provides an Elementor-style drag-and-drop page builder using Livewire.
+
+See [roadmap.md](./roadmap.md) for full instructions.
+

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,40 @@
+# Laravel 12 Elementor Style Builder Demo
+
+This document provides a roadmap for setting up a demo project in Laravel 12 with a drag-and-drop page builder similar to WordPress Elementor.
+
+## 1. Environment Setup
+1. Install [Composer](https://getcomposer.org/download/).
+2. Install [Node.js and npm](https://nodejs.org/).
+3. Run `composer create-project laravel/laravel my-builder-demo "^12.0"` to create the project.
+4. Change directory: `cd my-builder-demo`.
+5. Run `npm install` and `npm run build` to compile frontend assets.
+
+## 2. Livewire Installation
+1. Run `composer require livewire/livewire`.
+2. Include Livewire scripts and styles in `resources/views/layouts/app.blade.php`.
+3. Optionally install [Laravel Breeze](https://laravel.com/docs/12.x/starter-kits) for authentication: `composer require laravel/breeze --dev` then `php artisan breeze:install`.
+
+## 3. Builder Component
+1. Create a `Builder` Livewire component: `php artisan make:livewire Builder`.
+2. In the component view (`resources/views/livewire/builder.blade.php`), use TailwindCSS for a simple grid.
+3. Implement drag-and-drop with the [Alpine.js](https://alpinejs.dev/) `sortable` plugin or with a library like `SortableJS`.
+4. Store the layout in a JSON column in the database. Run a migration to create a `pages` table with `content` JSON field.
+5. The component should load and save the JSON layout using Livewire actions.
+
+## 4. Basic Widgets
+1. Create simple widgets (text block, image block, button block) as Blade partials.
+2. Use Livewire to dynamically render selected widgets into the builder grid.
+3. Provide minimal styling with TailwindCSS.
+
+## 5. Demo Page
+1. Create a demo route in `routes/web.php` to show the builder: `Route::get('/builder', Builder::class);`
+2. Allow saving the JSON layout to the database and retrieving it for editing.
+
+## 6. Next Steps
+- Expand with authentication and user-specific pages.
+- Add more widgets and style options.
+- Introduce versioning or templates.
+- Optionally explore Vue or React for more advanced drag-and-drop interactions.
+
+This roadmap offers a high-level overview. You can adapt it according to the project's complexity and the chosen libraries.
+


### PR DESCRIPTION
## Summary
- add README to point to project roadmap
- add roadmap with steps for creating a Laravel 12 demo using Livewire

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `composer test` *(fails: command not found)*